### PR TITLE
Removing the readyState enums

### DIFF
--- a/addon/mixins/sockets.js
+++ b/addon/mixins/sockets.js
@@ -26,7 +26,7 @@ export default Ember.Mixin.create({
 			If the ready state is closed this is because the route closed the socket on a previous
 			deactivate and now we are back into this same route so we need to reopen (create) it.
 		*/
-		if(!websocket || websocket.readyState === ENUMS.READY_STATES.CLOSED) {
+		if(!websocket || websocket.readyState === window.WebSocket.CLOSED) {
 			websocket = new window.WebSocket(socketURL);
 			urlHashKey = websocket.url;
 
@@ -73,7 +73,7 @@ export default Ember.Mixin.create({
 	*/
 	validateSocketURL: function(socketURL) {
 		var wsProtocolRegex = /^(ws|wss):\/\//i;
-		
+
 		if(!Ember.isEmpty(socketURL) && socketURL.match(wsProtocolRegex)) {
 			return true;
 		}
@@ -131,7 +131,7 @@ export default Ember.Mixin.create({
 			}
 
 			// Only send the data if we have an active connection
-			if(socketConnection && typeOf(socketConnection.send) === 'function' && socketConnection.readyState === ENUMS.READY_STATES.OPEN) {
+			if(socketConnection && typeOf(socketConnection.send) === 'function' && socketConnection.readyState === window.WebSocket.OPEN) {
 				socketConnection.send(data);
 			}
 		},

--- a/addon/utils/enums.js
+++ b/addon/utils/enums.js
@@ -1,9 +1,3 @@
 export default {
-    READY_STATES: {
-        CONNECTING: 0,
-        OPEN: 1,
-        CLOSING: 2,
-        CLOSED: 3
-    },
     SOCKET_EVENTS: ['onclose', 'onerror', 'onmessage', 'onopen']
 };


### PR DESCRIPTION
Moving from the readyState enums to their proper place which hangs
off of WebSocket. This changes: ENUMS.READY_STATES.OPEN to
window.WebSocket.OPEN.
