### PR TITLE
[BUGFIX] Fixing issue w/ dynamic routes

### DIFF
--- a/addon/mixins/sockets.js
+++ b/addon/mixins/sockets.js
@@ -178,10 +178,24 @@ export default Ember.Mixin.create({
 	},
 
 	/*
-	* When the route deactivates or "transitions away" we will either close the
-	* connection or keep it "alive"
+	* When the route deactivates (ie transitions away) or resets (ie a dynamic segment of a route is updated)
+	* we will either close the connection or keep it "alive". This logic used to be contained
+	* within the deactivate method but if you have a single route with a dynamic segment than
+	* the "deactive" method is never called. EX: if you have something like this:
+	*
+	* updateSocketURL: function(roomID) {
+	*   this.set('socketURL', 'ws://localhost:8080/room/%@'.fmt(roomID));
+	* },
+	*
+	* setupController: function(controller, model) {
+	*   this.updateSocketURL(model.id);
+	*   this._super.apply(this, arguments);
+	* }
+	*
+	* And if you transitioned from room/1 to room/2. The room/1 socket would not close thus we needed to
+	* place this logic on the resetController.
 	*/
-	deactivate: function() {
+	resetController: function() {
 		var socketContexts       = this.get('socketContexts');
 		var keepSocketAlive      = this.get('keepSocketAlive');
 		var socketConfigurations = this.get('socketConfigurations');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-websockets",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "EmberJS WebSockets addon for both Ember-CLI & non CLI Ember apps.",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/app/controllers/sockets/dynamic.js
+++ b/tests/dummy/app/controllers/sockets/dynamic.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+
+    actions: {
+        onopen: function() {},
+        onclose: function() {}
+    }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
     this.resource('sockets', function() {
         this.route('chatroom');
         this.route('multichat');
+        this.route('dynamic', {path: 'dynamic/:room_id'});
     });
 
     // Used for intergration tests

--- a/tests/dummy/app/routes/sockets/dynamic.js
+++ b/tests/dummy/app/routes/sockets/dynamic.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+import socketMixin from 'ember-websockets/mixins/sockets';
+
+export default Ember.Route.extend(socketMixin, {
+
+    socketURL: null,
+
+    updateSocketURL: function(roomID) {
+        this.set('socketURL', 'ws://localhost:8080/room/%@'.fmt(roomID));
+    },
+
+    model: function(params) {
+        return {id: params.room_id};
+    },
+
+    setupController: function(controller, model) {
+        this.updateSocketURL(model.id);
+        this._super.apply(this, arguments);
+    }
+});

--- a/tests/dummy/app/templates/sockets/dynamic.hbs
+++ b/tests/dummy/app/templates/sockets/dynamic.hbs
@@ -1,0 +1,3 @@
+<br>
+{{link-to '123 Dynamic Route' 'sockets.dynamic' 123}}
+{{link-to '321 Dynamic Route' 'sockets.dynamic' 321}}


### PR DESCRIPTION
Fixes: #12

In order to address an issue where a transition from a dynamic route to
the same route with a different dynamic segment: IE: room/1 to room/2
never closed the socket.