### PR TITLE
wraps sending actions to controllers with Ember.run

### DIFF
--- a/addon/mixins/sockets.js
+++ b/addon/mixins/sockets.js
@@ -141,7 +141,9 @@ export default Ember.Mixin.create({
 
 					// Only fire the action on the socket we care about.
 					if(context.websocket === data.target) {
-						context.controller.send(eventName, data);
+                        Ember.run(function(){
+                            context.controller.send(eventName, data);
+                        });
 					}
 				});
 			};


### PR DESCRIPTION
* it prevents tests from `You have turned on testing mode...` error
* also fixes: https://github.com/thoov/mock-socket/issues/8

So I've ended up with this solution of [this problem](https://github.com/thoov/mock-socket/issues/8). I think it's even better since mock-socket should be framework agnostic as I understand.