### PR TITLE
Allow websocket URL to contain query string params

### DIFF
--- a/addon/mixins/normalize-url.js
+++ b/addon/mixins/normalize-url.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+  /*
+  * The native websocket object will transform urls without a pathname to have just a /.
+  * As an example: ws://localhost:8080 would actually be ws://localhost:8080/ but ws://example.com/foo would not
+  * change. This function does this transformation to stay inline with the native websocket implementation.
+  */
+  normalizeURL(url) {
+    var parsedUrl = new URI(url);
+    var path = parsedUrl.path();
+    var query = parsedUrl.query();
+
+    if (path === '/') {
+      if(query === '' && url.slice(-1) !== '/') {
+        return url + '/';
+      }
+
+      if(query !== '' && url.indexOf('/?') === -1) {
+        return url.replace('?', '/?');
+      }
+    }
+
+    return url;
+  }
+});

--- a/app/services/primus.js
+++ b/app/services/primus.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 import PrimusProxy from 'ember-websockets/helpers/primus-proxy';
+import NormalizeUrlMixin from 'ember-websockets/mixins/normalize-url';
 
 const forEach = Array.prototype.forEach;
 const filter  = Array.prototype.filter;
 const isArray = Ember.isArray;
 
-export default Ember.Service.extend({
+export default Ember.Service.extend(NormalizeUrlMixin, {
   /*
   * Each element in the array is of the form:
   *
@@ -77,21 +78,6 @@ export default Ember.Service.extend({
       }
     });
     this.set('sockets', Ember.A(filteredSockets));
-  },
-
-  /*
-  * The native websocket object will transform urls without a pathname to have just a /.
-  * As an example: ws://localhost:8080 would actually be ws://localhost:8080/ but ws://example.com/foo would not
-  * change. This function does this transformation to stay inline with the native websocket implementation.
-  */
-  normalizeURL(url) {
-    var parsedUrl = new URI(url);
-
-    if(parsedUrl.path() === '/' && url.slice(-1) !== '/') {
-      return url + '/';
-    }
-
-    return url;
   },
 
   primusIsNotClosed(websocket) {

--- a/app/services/socket-io.js
+++ b/app/services/socket-io.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 import SocketIOProxy from 'ember-websockets/helpers/socketio-proxy';
+import NormalizeUrlMixin from 'ember-websockets/mixins/normalize-url';
 
 var filter = Array.prototype.filter;
 var forEach = Array.prototype.forEach;
 
-export default Ember.Service.extend({
+export default Ember.Service.extend(NormalizeUrlMixin, {
   /*
   * Each element in the array is of the form:
   *
@@ -43,22 +44,6 @@ export default Ember.Service.extend({
     });
 
     return proxy;
-  },
-
-  /*
-  * The native websocket object will transform urls without a pathname to have just a /.
-  * As an example: ws://localhost:8080 would actually be ws://localhost:8080/ but ws://example.com/foo would not
-  * change. This function does this transformation to stay inline with the native websocket implementation.
-  *
-  */
-  normalizeURL(url) {
-    var parsedUrl = new URI(url);
-
-    if(parsedUrl.path() === '/' && url.slice(-1) !== '/') {
-      return url + '/';
-    }
-
-    return url;
   },
 
   socketIsNotClosed(socket) {

--- a/app/services/websockets.js
+++ b/app/services/websockets.js
@@ -83,13 +83,21 @@ export default Ember.Service.extend({
   * change. This function does this transformation to stay inline with the native websocket implementation.
   */
   normalizeURL(url) {
-    return url; // FIXME: make a real fix when able to run tests.
     var parsedUrl = new URI(url);
-    if(parsedUrl.path() === '/' && url.slice(-1) !== '/') {
-      return url + '/';
+
+    if (parsedUrl.path() !== '/') {
+      return url;
     }
 
-    return url;
+    var normalizedURL = url;
+
+    if (parsedUrl.query() === '' && url.slice(-1) !== '/') {
+      normalizedURL = url + '/';
+    } else if (url.indexOf('/?') == -1) {
+      normalizedURL = url.replace('?', '/?');
+    }
+
+    return normalizedURL;
   },
 
   websocketIsNotClosed(websocket) {

--- a/app/services/websockets.js
+++ b/app/services/websockets.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 import WebsocketProxy from 'ember-websockets/helpers/websocket-proxy';
+import NormalizeUrlMixin from 'ember-websockets/mixins/normalize-url';
 
 const forEach = Array.prototype.forEach;
 const filter  = Array.prototype.filter;
 const isArray = Ember.isArray;
 
-export default Ember.Service.extend({
+export default Ember.Service.extend(NormalizeUrlMixin, {
   /*
   * Each element in the array is of the form:
   *
@@ -75,29 +76,6 @@ export default Ember.Service.extend({
     });
 
     this.set('sockets', Ember.A(filteredSockets));
-  },
-
-  /*
-  * The native websocket object will transform urls without a pathname to have just a /.
-  * As an example: ws://localhost:8080 would actually be ws://localhost:8080/ but ws://example.com/foo would not
-  * change. This function does this transformation to stay inline with the native websocket implementation.
-  */
-  normalizeURL(url) {
-    var parsedUrl = new URI(url);
-
-    if(parsedUrl.path() !== '/') {
-      return url;
-    }
-
-    var normalizedURL = url;
-
-    if(parsedUrl.query() === '' && url.slice(-1) !== '/') {
-      normalizedURL = url + '/';
-    } else if(url.indexOf('/?') == -1) {
-      normalizedURL = url.replace('?', '/?');
-    }
-
-    return normalizedURL;
   },
 
   websocketIsNotClosed(websocket) {

--- a/app/services/websockets.js
+++ b/app/services/websockets.js
@@ -83,8 +83,8 @@ export default Ember.Service.extend({
   * change. This function does this transformation to stay inline with the native websocket implementation.
   */
   normalizeURL(url) {
+    return url; // FIXME: make a real fix when able to run tests.
     var parsedUrl = new URI(url);
-
     if(parsedUrl.path() === '/' && url.slice(-1) !== '/') {
       return url + '/';
     }

--- a/app/services/websockets.js
+++ b/app/services/websockets.js
@@ -85,15 +85,15 @@ export default Ember.Service.extend({
   normalizeURL(url) {
     var parsedUrl = new URI(url);
 
-    if (parsedUrl.path() !== '/') {
+    if(parsedUrl.path() !== '/') {
       return url;
     }
 
     var normalizedURL = url;
 
-    if (parsedUrl.query() === '' && url.slice(-1) !== '/') {
+    if(parsedUrl.query() === '' && url.slice(-1) !== '/') {
       normalizedURL = url + '/';
-    } else if (url.indexOf('/?') == -1) {
+    } else if(url.indexOf('/?') == -1) {
       normalizedURL = url.replace('?', '/?');
     }
 

--- a/tests/unit/services/websockets/normalize-url-test.js
+++ b/tests/unit/services/websockets/normalize-url-test.js
@@ -38,3 +38,25 @@ test('that normalizeURL works correctly', assert => {
     }
   }).create();
 });
+
+test('that normalizeURL works correctly if url contains query params', assert => {
+  var done = assert.async();
+
+  assert.expect(6);
+
+  component = ConsumerComponent.extend({
+    init() {
+      this._super.apply(this, arguments);
+      var socketService = this.socketService;
+
+      assert.equal(socketService.normalizeURL('ws://example.com/?param=value'), 'ws://example.com/?param=value');
+      assert.equal(socketService.normalizeURL('ws://example.com?param=value'), 'ws://example.com/?param=value');
+      assert.equal(socketService.normalizeURL('ws://example.com:8000/?param=value'), 'ws://example.com:8000/?param=value');
+      assert.equal(socketService.normalizeURL('ws://example.com:8000?param=value'), 'ws://example.com:8000/?param=value');
+      assert.equal(socketService.normalizeURL('ws://example.com:8000/foo?param=value'), 'ws://example.com:8000/foo?param=value');
+      assert.equal(socketService.normalizeURL('ws://example.com:8000/foo/?param=value'), 'ws://example.com:8000/foo/?param=value');
+
+      done();
+    }
+  }).create();
+});


### PR DESCRIPTION
Refactored WebSocketService#normalizeURL method to handle URL with query params correctly (add / before ?, not to the end of the URL).