### PR TITLE
Double connection for new websocket proxy objects

### DIFF
--- a/app/services/websockets.js
+++ b/app/services/websockets.js
@@ -48,7 +48,7 @@ export default Service.extend({
       return newWebSocket;
     }
 
-    const newProxy = WebsocketProxy.create({ content: this, protocols, socket: new WebSocket(normalizeURL(url), protocols) });
+    const newProxy = WebsocketProxy.create({ content: this, protocols, socket: newWebSocket });
 
     this.set(`sockets.${normalizeURL(url)}`, { url: newProxy.socket.url, socket: newProxy });
 


### PR DESCRIPTION
When calling `socketFor` and creating a new proxy object, `new WebSocket(normalizeURL(url), protocols)` gets called twice, creating two connections to the websocket server. This PR uses the first socket created for updating an existing proxy object or creating a new one.