### PR TITLE
Add FastBoot Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4.5.0"
 
 sudo: false
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,7 +15,10 @@ module.exports = function(defaults) {
   */
 
   app.import('bower_components/urijs/src/URI.min.js');
-  app.import('bower_components/socket.io-client/socket.io.js');
+  
+  if (!process.env.EMBER_CLI_FASTBOOT) {
+    app.import('bower_components/socket.io-client/socket.io.js');
+  }
 
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
 
   /**
   * https://github.com/ember-cli/ember-cli/issues/2949#issuecomment-85634073
-  * 
+  *
   * The addon tree is augmented with the impagination modules. This
   * makes them available not only to `ember-impagination` as a whole,
   * but also to the application if they want to embed it. It'll look
@@ -59,7 +59,7 @@ module.exports = {
       /*
       * Only import the socket.io file if one is found
       */
-      if(stats.isFile()) {
+      if(stats.isFile() && !process.env.EMBER_CLI_FASTBOOT) {
         app.import(socketIOPath);
       }
     }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ember-cli": "2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-fastboot": "1.0.0-beta.8",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli": "2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-fastboot": "1.0.0-beta.9",
+    "ember-cli-fastboot": "^1.0.0-beta.9",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli": "2.7.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-fastboot": "1.0.0-beta.8",
+    "ember-cli-fastboot": "1.0.0-beta.9",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",


### PR DESCRIPTION
Addresses Issue #83 

These first three commits are enough to get a fresh ember app with `ember-cli-fastboot` and `ember-websockets` to boot up in FastBoot mode with `ember fastboot`. I haven't had a chance to extensively test an actual app yet so its very possible that the exclusion of the socket.io client may cause some issues. Further testing is needed.