### PR TITLE
Fix sockets object leaking across instances

### DIFF
--- a/addon/services/websockets.js
+++ b/addon/services/websockets.js
@@ -13,7 +13,9 @@ export default Service.extend({
       'websocket-url': WebSocket Proxy object
     }
   */
-  sockets: {},
+  sockets: Ember.computed(function() {
+    return {};
+  }),
 
   /*
     socketFor returns a websocket proxy object. On this object there is a property `socket`


### PR DESCRIPTION
If you define arrays or objects inside of the class body of an Ember.Object, they'll be stored in the prototype and be shared across every instance.