### PR TITLE
Compatibility with ember-cli < 2.7

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,21 @@ module.exports = {
     this._super.included.apply(this, arguments);
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
-      var host = this._findHost();
+      var host;
+      
+      // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+      // use that.
+      if (typeof this._findHost === 'function') {
+        host = this._findHost();
+      } else {
+        // Otherwise, we'll use this implementation borrowed from the _findHost()
+        // method in ember-cli.
+        var current = this;
+        do {
+          host = current.app || host;
+        } while (current.parent.parent && (current = current.parent));
+      }
+
       var socketIOPath = host.bowerDirectory + '/socket.io-client/dist/socket.io.js';
       var uriPath = host.bowerDirectory + '/urijs/src/URI.min.js';
 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = {
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
       var host;
-      
+
       // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
       // use that.
       if (typeof this._findHost === 'function') {
@@ -60,14 +60,14 @@ module.exports = {
       var socketIOPath = host.bowerDirectory + '/socket.io-client/dist/socket.io.js';
       var uriPath = host.bowerDirectory + '/urijs/src/URI.min.js';
 
-      this.import(uriPath);
+      host.import(uriPath);
 
       // Only import the socket.io file if one is found
       try {
         var stats = fs.lstatSync(socketIOPath);
 
         if(stats.isFile()) {
-          this.import(socketIOPath);
+          host.import(socketIOPath);
         }
       }
       catch(e) {}


### PR DESCRIPTION
Hi,

The current implementation of the addon was not compatible with ember-cli < 2.7 because of the use of findHost and import directly. 

This PR makes the addon compatible by using findHost only if this is a defined function and falling back to the old implementation if necessary. 