### PR TITLE
existingProxy.socket property should be updated using Ember.set() method

### DIFF
--- a/addon/services/websockets.js
+++ b/addon/services/websockets.js
@@ -59,7 +59,7 @@ export default Service.extend({
         If there is an existing socket in place we simply update the websocket object and not
         the whole proxy as we dont want to destroy the previous listeners.
       */
-      existingProxy.socket = newWebSocket;
+      set(existingProxy, 'socket', newWebSocket);
       return existingProxy;
     }
 


### PR DESCRIPTION
If there's a existingProxy, Ember will throw an error when trying to set the socket property directly instead of using Ember.set()