### PR TITLE
replace babel with browserify to support ember 2.12-beta

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,41 +2,9 @@
 'use strict';
 
 var fs = require('fs');
-var BabelTranspiler = require('broccoli-babel-transpiler');
-var Funnel = require('broccoli-funnel');
-var MergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-websockets',
-
-  /**
-  * https://github.com/ember-cli/ember-cli/issues/2949#issuecomment-85634073
-  *
-  * The addon tree is augmented with the mock-socket modules. This
-  * makes them available not only to `ember-websocket` as a whole,
-  * but also to the application if they want to embed it.
-  */
-  treeForAddon: function() {
-    // get the base addon tree
-    var addonTree = this._super.treeForAddon.apply(this, arguments);
-
-    // transpile the mock-socket sources into ES5. However, we want
-    // to leave the ES6 module declaration in place because they'll be
-    // handled later by ember-cli.
-    var transpiled = new BabelTranspiler('node_modules/mock-socket/src', {
-      loose: true,
-      blacklist: ['es6.modules']
-    });
-
-    // take the transpiled mock-socket sources and put them into
-    // `modules/mock-socket/{server|websocket}.js` so that the
-    // ember-cli build will pick them up.
-    var mockSocket = new Funnel(transpiled, {
-      destDir: 'modules/mock-socket'
-    });
-
-    return new MergeTrees([addonTree, mockSocket]);
-  },
 
   included: function() {
     this._super.included.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
+    "ember-browserify": "1.1.13",
     "ember-cli": "2.11.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
There is an issue in ember 2.12-beta where this addon ends up putting uncompiled es6 directly into the app's vendor.js file. Seeing as this was originally following ember-impagination, I updated it with ember-impagination's [solution to fixing the issue](https://github.com/thefrontside/ember-impagination/commit/e39fa42cab08df6e47d5ce488159d8685c336788). (browserify)