### PR TITLE
use mock sockets 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-babel": "^5.1.7",
     "exists-sync": "0.0.4",
     "fastboot-transform": "^0.1.0",
-    "mock-socket": "^6.0.1",
+    "mock-socket": "^6.1.0",
     "socket.io-client": "^1.7.3",
     "urijs": "^1.18.9"
   },


### PR DESCRIPTION
mock-sockets 6.0 breaks in ember 2.13

This PR upgrades to 6.1, fixing the issue with Ember 2.13