### PR TITLE
fix broccoli funnel issue where dist directory did not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = {
       new Funnel(__dirname + '/vendor', { destDir: this.name }),
       fastbootTransform(new Funnel(path.dirname(urijsPath), { destDir: this.name + '/urijs' })),
       new Funnel(path.dirname(mockSocketPath), { destDir: this.name + '/mock-socket' }),
-      fastbootTransform(new Funnel(path.join(path.dirname(socketIOClientPath), '../dist'), { destDir: this.name + '/socket.io-client' }))
+      fastbootTransform(new Funnel(path.join(path.dirname(socketIOClientPath), '../'), { destDir: this.name + '/socket.io-client' }))
     ]);
   },
 


### PR DESCRIPTION
WIth fresh install I get the following error:
```
The Broccoli Plugin: [Funnel] failed with:
Error: Attempting to watch missing directory: /var/www/socket-test/node_modules/socket.io-client/dist
    at EventEmitter.Watcher_addWatchDir [as addWatchDir] (/var/www/socket-test/node_modules/ember-cli-broccoli-sane-watcher/index.js:142:11)
    at /var/www/socket-test/node_modules/broccoli-builder/lib/builder.js:132:35
    at tryCatch (/var/www/socket-test/node_modules/rsvp/dist/rsvp.js:539:12)
    at invokeCallback (/var/www/socket-test/node_modules/rsvp/dist/rsvp.js:554:13)
    at /var/www/socket-test/node_modules/rsvp/dist/rsvp.js:629:16
    at flush (/var/www/socket-test/node_modules/rsvp/dist/rsvp.js:2414:5)
    at nextTickCallbackWith0Args (node.js:489:9)
    at process._tickCallback (node.js:418:13)

The broccoli plugin was instantiated at: 
    at Funnel.Plugin (/var/www/socket-test/node_modules/broccoli-plugin/index.js:7:31)
    at new Funnel (/var/www/socket-test/node_modules/broccoli-funnel/index.js:58:10)
    at Class.treeForVendor (/var/www/socket-test/node_modules/ember-websockets/index.js:33:25)
    at Class._treeFor (/var/www/socket-test/node_modules/ember-cli/lib/models/addon.js:520:33)
    at Class.treeFor (/var/www/socket-test/node_modules/ember-cli/lib/models/addon.js:480:21)
    at /var/www/socket-test/node_modules/ember-cli/lib/broccoli/ember-app.js:547:22
    at Array.map (native)
    at EmberApp.addonTreesFor (/var/www/socket-test/node_modules/ember-cli/lib/broccoli/ember-app.js:545:32)
    at EmberApp._processedVendorTree (/var/www/socket-test/node_modules/ember-cli/lib/broccoli/ember-app.js:969:24)
    at EmberApp._processedExternalTree (/var/www/socket-test/node_modules/ember-cli/lib/broccoli/ember-app.js:997:25)
```

The corresponding change I made fixes my issue.  Not entirely sure what the downstream affects are.