### PR TITLE
Replace urijs with native URL interface.

### DIFF
--- a/addon/helpers.js
+++ b/addon/helpers.js
@@ -4,21 +4,7 @@
 * change. This function does this transformation to stay inline with the native websocket implementation.
 */
 export function normalizeURL(url) {
-  const parsedUrl = new URI(url);
-  const path = parsedUrl.path();
-  const query = parsedUrl.query();
-
-  if (path === '/') {
-    if(query === '' && url.slice(-1) !== '/') {
-      return url + '/';
-    }
-
-    if(query !== '' && url.indexOf('/?') === -1) {
-      return url.replace('?', '/?');
-    }
-  }
-
-  return url;
+  return new URL(url).toString();
 }
 
 /*

--- a/index.js
+++ b/index.js
@@ -14,21 +14,17 @@ module.exports = {
     this._super.included.apply(this, arguments);
     this._shimImport();
 
-    this.import(`vendor/${this.name}/urijs/URI.min.js`);
-
     if (this._readConfigProp('socketIO') === true) {
       this.import(`vendor/${this.name}/socket.io-client/socket.io.slim.js`);
     }
   },
 
   treeForVendor() {
-    const urijsPath = require.resolve('urijs');
     const mockSocketPath = require.resolve('mock-socket');
     const socketIOClientPath = require.resolve('socket.io-client');
 
     return new Merge([
       new Funnel(__dirname + '/vendor', { destDir: this.name }),
-      fastbootTransform(new Funnel(path.dirname(urijsPath), { destDir: this.name + '/urijs' })),
       new Funnel(path.dirname(mockSocketPath), { destDir: this.name + '/mock-socket' }),
       fastbootTransform(new Funnel(path.join(path.dirname(socketIOClientPath), '../dist'), { destDir: this.name + '/socket.io-client' }))
     ]);

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "glob": "^7.1.2",
     "mock-socket": "^7.1.0",
     "morgan": "^1.9.0",
-    "socket.io-client": "^2.1.1",
-    "urijs": "^1.19.0"
+    "socket.io-client": "^2.1.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7582,10 +7582,6 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
   integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
 
-urijs@^1.19.0:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.1.tgz#5b0ff530c0cbde8386f6342235ba5ca6e995d25a"
-
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"


### PR DESCRIPTION
As urijs was quite big, this gives a nice reduction in bundle size.
Polyfills for URL are available through babel/core-js.